### PR TITLE
fix : fix wrong description of development language

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-c# Finite Square Well
+C++ Finite Square Well
 In quantum mechanics, the energy eigenvalues of finite potential square well is given by transcendental equation. Therefore, it can be solved numerically, using a computer or graphically. In this file, one-variable Newton's method is used to find the roots of eigenenergys.
 
 ## System conditions


### PR DESCRIPTION
Wrong description of development language.

[C#](https://zh.wikipedia.org/zh-tw/C%E2%99%AF) -> [C++](https://zh.wikipedia.org/zh-tw/C%2B%2B)